### PR TITLE
Fix inconsistent behavior when using > and |

### DIFF
--- a/shpaml/shpaml.py
+++ b/shpaml/shpaml.py
@@ -241,6 +241,11 @@ def tag_and_rest(tag):
 
 def enclose_tag(tag, text):
     start_tag, end_tag = apply_jquery_sugar(tag)
+    if start_tag.startswith('<>'):
+        start_tag = '<'+start_tag[3:]
+    if end_tag.endswith('</>>'):
+        tag = tag.split(' ')[1]
+        end_tag = '</'+tag+'>'+end_tag[:0]
     return start_tag + text + end_tag
 
 def enclose_django_tag(tag, text):


### PR DESCRIPTION
If you write

```
title | content inside title
```

It outputs

```
<title> content inside title </title>
```

If you write

```
> title
```

it outputs

```
<title></title>
```

But if you write

```
> title | content inside title
```

It would wrongly output

```
<> title>content inside title</>>
```

With this patch using

```
>
```

As a prefix for your lines it will work as expected
